### PR TITLE
Remove dependency on jq

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 xcuserdata/
 DerivedData/
 .swiftpm/xcode
+Fixtures/sample-package/.swiftpm

--- a/Fixtures/sample-package/Package.resolved
+++ b/Fixtures/sample-package/Package.resolved
@@ -1,0 +1,50 @@
+{
+  "originHash" : "7d6e91653227c9e7701c7af742e1f174f932a2e42971080e6083b4b5e61c76e5",
+  "pins" : [
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "0fbc8848e389af3bb55c182bc19ca9d5dc2f255b",
+        "version" : "1.4.0"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "branch" : "main",
+        "revision" : "1f2007ef4165432f59f28615c473eb79a844a2af"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types",
+      "state" : {
+        "revision" : "1ddbea1ee34354a6a2532c60f98501c35ae8edfa",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "9cb486020ebf03bfa5b5df985387a14a98744537",
+        "version" : "1.6.1"
+      }
+    },
+    {
+      "identity" : "swift-openapi-runtime",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-openapi-runtime",
+      "state" : {
+        "revision" : "e80046bc806e27b9cc0b052eb325a04664de66ae"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Fixtures/sample-package/Package.swift
+++ b/Fixtures/sample-package/Package.swift
@@ -1,0 +1,14 @@
+// swift-tools-version: 5.10
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "sample-package",
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-argument-parser.git", exact: "1.4.0"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-openapi-runtime", revision: "e80046bc806e27b9cc0b052eb325a04664de66ae"),
+        .package(url: "https://github.com/apple/swift-atomics.git", branch: "main"),
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         
         // Swift Package Manager Stuff
         .target(name: "SwiftPackageManager"),
-        .testTarget(name: "SwiftPackageManagerTests", dependencies: ["SwiftPackageManager"]),
+        .testTarget(name: "SwiftPackageManagerTests", dependencies: ["SwiftPackageManager"], resources: [.copy("agamotto-package-dump.json")]),
         
         // Core
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         
         // Swift Package Manager Stuff
         .target(name: "SwiftPackageManager"),
-        .testTarget(name: "SwiftPackageManagerTests", dependencies: ["SwiftPackageManager"], resources: [.copy("agamotto-package-dump.json")]),
+        .testTarget(name: "SwiftPackageManagerTests", dependencies: ["SwiftPackageManager"], resources: [.copy("sample-package-dump.json")]),
         
         // Core
         .target(
@@ -39,6 +39,6 @@ let package = Package(
         .executableTarget(name: "Run", dependencies: [
             .byName(name: "Core"),
             .product(name: "ArgumentParser", package: "swift-argument-parser"),
-        ])
+        ]),
     ]
 )

--- a/Sources/SwiftPackageManager/ManifestParser.swift
+++ b/Sources/SwiftPackageManager/ManifestParser.swift
@@ -1,26 +1,5 @@
 import Foundation
 
-struct CacheKind {
-    let filename: String
-}
-
-extension CacheKind {
-    static let swiftPackageDirectoryDump = CacheKind(filename: "dump.log")
-    
-    static let jqFilterResult = CacheKind(filename: "jq-filter.log")
-}
-
-private extension URL {
-    func path(for kind: CacheKind) -> String {
-        #if os(Linux)
-        appendingPathComponent(kind.filename).path
-        #else
-        appending(path: kind.filename).path()
-        #endif
-    }
-}
-
-
 public struct RuntimeError: LocalizedError {
     public let message: String
     

--- a/Sources/SwiftPackageManager/PackageDumpResponse.swift
+++ b/Sources/SwiftPackageManager/PackageDumpResponse.swift
@@ -5,9 +5,14 @@ public struct PackageDumpResponse: Decodable {
         let remote: [[String: String]]
     }
     
+    public struct Requirement: Decodable {
+        let exact: [String]?
+    }
+    
     public struct SourceControl: Decodable {
         let identity: String
         let location: SourceControlLocation
+        let requirement: Requirement
     }
     
     public struct Dependency: Decodable {

--- a/Sources/SwiftPackageManager/PackageDumpResponse.swift
+++ b/Sources/SwiftPackageManager/PackageDumpResponse.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+public struct PackageDumpResponse: Decodable {
+    public struct SourceControlLocation: Decodable {
+        let remote: [[String: String]]
+    }
+    
+    public struct SourceControl: Decodable {
+        let identity: String
+        let location: SourceControlLocation
+    }
+    
+    public struct Dependency: Decodable {
+        let sourceControl: [SourceControl]
+    }
+    
+    public let dependencies: [Dependency]
+    
+}

--- a/Tests/SwiftPackageManagerTests/ManifestParserTests.swift
+++ b/Tests/SwiftPackageManagerTests/ManifestParserTests.swift
@@ -43,26 +43,26 @@ final class ManifestParserTests: XCTestCase {
         let dependencies = try parser.parsePackage(path: temporaryDirectoryPath())
         XCTAssertEqual(dependencies, [
             Dependency(
-              name: "swift-argument-parser",
-              cloneURL: CloneUrl(url: URL(string: "https://github.com/apple/swift-argument-parser.git")!),
-              version: "1.4.0"
+                name: "swift-argument-parser",
+                cloneURL: CloneUrl(url: URL(string: "https://github.com/apple/swift-argument-parser.git")!),
+                version: "1.4.0"
             ),
             Dependency(
-              name: "swift-log",
-              cloneURL: CloneUrl(url: URL(string: "https://github.com/apple/swift-log.git")!),
-              version: nil
+                name: "swift-log",
+                cloneURL: CloneUrl(url: URL(string: "https://github.com/apple/swift-log.git")!),
+                version: nil
             ),
             Dependency(
-              name: "swift-openapi-runtime",
-              cloneURL: CloneUrl(url: URL(string: "https://github.com/apple/swift-openapi-runtime")!),
-              version: nil
+                name: "swift-openapi-runtime",
+                cloneURL: CloneUrl(url: URL(string: "https://github.com/apple/swift-openapi-runtime")!),
+                version: nil
             ),
             Dependency(
-              name: "swift-atomics",
-              cloneURL: CloneUrl(url: URL(string: "https://github.com/apple/swift-atomics.git")!),
-              version: nil
-          ),
-          ])
+                name: "swift-atomics",
+                cloneURL: CloneUrl(url: URL(string: "https://github.com/apple/swift-atomics.git")!),
+                version: nil
+            ),
+        ])
     }
 }
 

--- a/Tests/SwiftPackageManagerTests/ManifestParserTests.swift
+++ b/Tests/SwiftPackageManagerTests/ManifestParserTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import SwiftPackageManager
+import Foundation
 
 private struct StaticCommandRunner: CommandRunning {
     let result: CommandRunResult
@@ -18,6 +19,16 @@ private struct StaticCommandRunner: CommandRunning {
 }
 
 final class ManifestParserTests: XCTestCase {
+    func testParsingJson() throws {
+        guard let path = Bundle.module.path(forResource: "agamotto-package-dump", ofType: "json") else {
+            return XCTFail("Unable to retrieve path to fixture")
+        }
+        
+        let content = try Data(contentsOf: URL(fileURLWithPath: path))
+        let response = try JSONDecoder().decode(PackageDumpResponse.self, from: content)
+        
+    }
+    
     func testParsePackage_validOutput() throws {
         let parser = ManifestParser(
             runner: StaticCommandRunner.withOutput("""

--- a/Tests/SwiftPackageManagerTests/ManifestParserTests.swift
+++ b/Tests/SwiftPackageManagerTests/ManifestParserTests.swift
@@ -18,54 +18,51 @@ private struct StaticCommandRunner: CommandRunning {
     }
 }
 
-final class ManifestParserTests: XCTestCase {
-    func testParsingJson() throws {
-        guard let path = Bundle.module.path(forResource: "agamotto-package-dump", ofType: "json") else {
-            return XCTFail("Unable to retrieve path to fixture")
-        }
-        
-        let content = try Data(contentsOf: URL(fileURLWithPath: path))
-        let response = try JSONDecoder().decode(PackageDumpResponse.self, from: content)
-        
+private struct OutputError: LocalizedError {
+    let message: String
+    
+    var errorDescription: String? { message }
+}
+
+private func readOutput(named name: String) throws -> Data {
+    guard let path = Bundle.module.path(forResource: name, ofType: "json") else {
+        throw OutputError(message: "Fixture \(name) does not exist")
     }
     
+    return try Data(contentsOf: URL(fileURLWithPath: path))
+}
+
+final class ManifestParserTests: XCTestCase {
     func testParsePackage_validOutput() throws {
         let parser = ManifestParser(
-            runner: StaticCommandRunner.withOutput("""
-[
-    { "name": "vapor", "cloneURL": "https://github.com/vapor/vapor.git", "version": "1.2.3" },
-    { "name": "fluent", "cloneURL": "https://github.com/vapor/fluent.git", "version": null }
-]
-"""),
+            runner: try StaticCommandRunner.withOutput(String(decoding: readOutput(named: "sample-package-dump"), as: UTF8.self)),
             cachesDirectory: temporaryDirectory(),
             isVerbose: true
         )
         
-        do {
-            let dependencies = try parser.parsePackage(path: temporaryDirectoryPath())
-            XCTAssertEqual(dependencies, [
-                Dependency(name: "vapor", cloneURL: CloneUrl(url: URL(string: "https://github.com/vapor/vapor.git")!), version: "1.2.3"),
-                Dependency(name: "fluent", cloneURL: CloneUrl(url: URL(string: "https://github.com/vapor/fluent.git")!), version: nil)
-            ])
-        } catch let error {
-            throw error
-        }
-        
-    }
-    
-    func testParsePackage_invalidOutput() throws {
-        let parser = ManifestParser(
-            runner: StaticCommandRunner.withOutput("[{ name: null, cloneURL: null, version: null }]"),
-            cachesDirectory: temporaryDirectory(),
-            isVerbose: true
-        )
-        
-        XCTAssertThrowsError(try parser.parsePackage(path: temporaryDirectoryPath())) { error in
-            guard let runtimeError = error as? RuntimeError else { return XCTFail() }
-            
-            XCTAssertTrue(runtimeError.message.contains("dump.log"))
-            XCTAssertTrue(runtimeError.message.contains("jq-filter.log"))
-        }
+        let dependencies = try parser.parsePackage(path: temporaryDirectoryPath())
+        XCTAssertEqual(dependencies, [
+            Dependency(
+              name: "swift-argument-parser",
+              cloneURL: CloneUrl(url: URL(string: "https://github.com/apple/swift-argument-parser.git")!),
+              version: "1.4.0"
+            ),
+            Dependency(
+              name: "swift-log",
+              cloneURL: CloneUrl(url: URL(string: "https://github.com/apple/swift-log.git")!),
+              version: nil
+            ),
+            Dependency(
+              name: "swift-openapi-runtime",
+              cloneURL: CloneUrl(url: URL(string: "https://github.com/apple/swift-openapi-runtime")!),
+              version: nil
+            ),
+            Dependency(
+              name: "swift-atomics",
+              cloneURL: CloneUrl(url: URL(string: "https://github.com/apple/swift-atomics.git")!),
+              version: nil
+          ),
+          ])
     }
 }
 

--- a/Tests/SwiftPackageManagerTests/agamotto-package-dump.json
+++ b/Tests/SwiftPackageManagerTests/agamotto-package-dump.json
@@ -1,0 +1,324 @@
+{
+  "cLanguageStandard" : null,
+  "cxxLanguageStandard" : null,
+  "dependencies" : [
+    {
+      "sourceControl" : [
+        {
+          "identity" : "swift-argument-parser",
+          "location" : {
+            "remote" : [
+              {
+                "urlString" : "https://github.com/apple/swift-argument-parser.git"
+              }
+            ]
+          },
+          "productFilter" : null,
+          "requirement" : {
+            "exact" : [
+              "1.4.0"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "sourceControl" : [
+        {
+          "identity" : "swift-log",
+          "location" : {
+            "remote" : [
+              {
+                "urlString" : "https://github.com/apple/swift-log.git"
+              }
+            ]
+          },
+          "productFilter" : null,
+          "requirement" : {
+            "exact" : [
+              "1.6.1"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "sourceControl" : [
+        {
+          "identity" : "swift-openapi-generator",
+          "location" : {
+            "remote" : [
+              {
+                "urlString" : "https://github.com/apple/swift-openapi-generator"
+              }
+            ]
+          },
+          "productFilter" : null,
+          "requirement" : {
+            "exact" : [
+              "1.2.1"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "sourceControl" : [
+        {
+          "identity" : "swift-openapi-runtime",
+          "location" : {
+            "remote" : [
+              {
+                "urlString" : "https://github.com/apple/swift-openapi-runtime"
+              }
+            ]
+          },
+          "productFilter" : null,
+          "requirement" : {
+            "exact" : [
+              "1.4.0"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "sourceControl" : [
+        {
+          "identity" : "swift-openapi-urlsession",
+          "location" : {
+            "remote" : [
+              {
+                "urlString" : "https://github.com/apple/swift-openapi-urlsession"
+              }
+            ]
+          },
+          "productFilter" : null,
+          "requirement" : {
+            "exact" : [
+              "1.0.1"
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "name" : "Agamotto",
+  "packageKind" : {
+    "root" : [
+      "/Users/palleas/Code/Agamotto"
+    ]
+  },
+  "pkgConfig" : null,
+  "platforms" : [
+    {
+      "options" : [
+
+      ],
+      "platformName" : "macos",
+      "version" : "13.0"
+    }
+  ],
+  "products" : [
+    {
+      "name" : "agamotto",
+      "settings" : [
+
+      ],
+      "targets" : [
+        "Run"
+      ],
+      "type" : {
+        "executable" : null
+      }
+    }
+  ],
+  "providers" : null,
+  "swiftLanguageVersions" : null,
+  "targets" : [
+    {
+      "dependencies" : [
+        {
+          "product" : [
+            "OpenAPIRuntime",
+            "swift-openapi-runtime",
+            null,
+            null
+          ]
+        },
+        {
+          "product" : [
+            "OpenAPIURLSession",
+            "swift-openapi-urlsession",
+            null,
+            null
+          ]
+        }
+      ],
+      "exclude" : [
+        "github-openapi-spec.yaml",
+        "openapi-generator-config.yaml"
+      ],
+      "name" : "GitHubClient",
+      "packageAccess" : true,
+      "resources" : [
+
+      ],
+      "settings" : [
+
+      ],
+      "type" : "regular"
+    },
+    {
+      "dependencies" : [
+
+      ],
+      "exclude" : [
+
+      ],
+      "name" : "SwiftPackageManager",
+      "packageAccess" : true,
+      "resources" : [
+
+      ],
+      "settings" : [
+
+      ],
+      "type" : "regular"
+    },
+    {
+      "dependencies" : [
+        {
+          "byName" : [
+            "SwiftPackageManager",
+            null
+          ]
+        }
+      ],
+      "exclude" : [
+
+      ],
+      "name" : "SwiftPackageManagerTests",
+      "packageAccess" : true,
+      "resources" : [
+        {
+          "path" : ".",
+          "rule" : {
+            "copy" : {
+
+            }
+          }
+        }
+      ],
+      "settings" : [
+
+      ],
+      "type" : "test"
+    },
+    {
+      "dependencies" : [
+        {
+          "byName" : [
+            "GitHubClient",
+            null
+          ]
+        },
+        {
+          "byName" : [
+            "SwiftPackageManager",
+            null
+          ]
+        },
+        {
+          "product" : [
+            "ArgumentParser",
+            "swift-argument-parser",
+            null,
+            null
+          ]
+        },
+        {
+          "product" : [
+            "Logging",
+            "swift-log",
+            null,
+            null
+          ]
+        }
+      ],
+      "exclude" : [
+
+      ],
+      "name" : "Core",
+      "packageAccess" : true,
+      "resources" : [
+
+      ],
+      "settings" : [
+
+      ],
+      "type" : "regular"
+    },
+    {
+      "dependencies" : [
+        {
+          "byName" : [
+            "Core",
+            null
+          ]
+        },
+        {
+          "byName" : [
+            "SwiftPackageManager",
+            null
+          ]
+        }
+      ],
+      "exclude" : [
+
+      ],
+      "name" : "CoreTests",
+      "packageAccess" : true,
+      "resources" : [
+
+      ],
+      "settings" : [
+
+      ],
+      "type" : "test"
+    },
+    {
+      "dependencies" : [
+        {
+          "byName" : [
+            "Core",
+            null
+          ]
+        },
+        {
+          "product" : [
+            "ArgumentParser",
+            "swift-argument-parser",
+            null,
+            null
+          ]
+        }
+      ],
+      "exclude" : [
+
+      ],
+      "name" : "Run",
+      "packageAccess" : true,
+      "resources" : [
+
+      ],
+      "settings" : [
+
+      ],
+      "type" : "executable"
+    }
+  ],
+  "toolsVersion" : {
+    "_version" : "5.9.0"
+  }
+}

--- a/Tests/SwiftPackageManagerTests/sample-package-dump.json
+++ b/Tests/SwiftPackageManagerTests/sample-package-dump.json
@@ -1,0 +1,110 @@
+{
+  "cLanguageStandard" : null,
+  "cxxLanguageStandard" : null,
+  "dependencies" : [
+    {
+      "sourceControl" : [
+        {
+          "identity" : "swift-argument-parser",
+          "location" : {
+            "remote" : [
+              {
+                "urlString" : "https://github.com/apple/swift-argument-parser.git"
+              }
+            ]
+          },
+          "productFilter" : null,
+          "requirement" : {
+            "exact" : [
+              "1.4.0"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "sourceControl" : [
+        {
+          "identity" : "swift-log",
+          "location" : {
+            "remote" : [
+              {
+                "urlString" : "https://github.com/apple/swift-log.git"
+              }
+            ]
+          },
+          "productFilter" : null,
+          "requirement" : {
+            "range" : [
+              {
+                "lowerBound" : "1.0.0",
+                "upperBound" : "2.0.0"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "sourceControl" : [
+        {
+          "identity" : "swift-openapi-runtime",
+          "location" : {
+            "remote" : [
+              {
+                "urlString" : "https://github.com/apple/swift-openapi-runtime"
+              }
+            ]
+          },
+          "productFilter" : null,
+          "requirement" : {
+            "revision" : [
+              "e80046bc806e27b9cc0b052eb325a04664de66ae"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "sourceControl" : [
+        {
+          "identity" : "swift-atomics",
+          "location" : {
+            "remote" : [
+              {
+                "urlString" : "https://github.com/apple/swift-atomics.git"
+              }
+            ]
+          },
+          "productFilter" : null,
+          "requirement" : {
+            "branch" : [
+              "main"
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "name" : "sample-package",
+  "packageKind" : {
+    "root" : [
+      "/Users/palleas/Code/Agamotto/Fixtures/sample-package"
+    ]
+  },
+  "pkgConfig" : null,
+  "platforms" : [
+
+  ],
+  "products" : [
+
+  ],
+  "providers" : null,
+  "swiftLanguageVersions" : null,
+  "targets" : [
+
+  ],
+  "toolsVersion" : {
+    "_version" : "5.10.0"
+  }
+}


### PR DESCRIPTION
This started out of laziness, but this is definitely not ideal. I realized while using agamotto on a package where the `swift package package-dump` command would fail, causing agamotto to fail with a cryptic error. The issue is that when you run something similar to `swift ... | jq`, the pipe operator swallow the exit code. Instead of fixing that (using the [pipefail bash option](https://www.gnu.org/software/bash/manual/html_node/Pipelines.html)), it was a good opportunity to just remove jq altogether. 

I'll update the homebrew formula as a follow up.  